### PR TITLE
Change scheduled run to daily

### DIFF
--- a/.github/workflows/tokendrip.yml
+++ b/.github/workflows/tokendrip.yml
@@ -1,7 +1,7 @@
 name: TokenDrip
 on:
-  # schedule:
-  #   - cron: "17 * * * *"  # Run at 17 minutes past every hour
+  schedule:
+    - cron: "0 0 * * *"  # Run once daily at 00:00 UTC
   workflow_dispatch:      # Allow manual triggering
     inputs:
       test_mode:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Schedule long-running OpenAI jobs that automatically pause when daily free-token
 1. Fork this repository
 2. Add your `OPENAI_API_KEY` as a repository secret
 3. Push to trigger the workflow
-4. Tasks run hourly via GitHub Actions
+4. Tasks run daily at 00:00 UTC via GitHub Actions
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- run workflow at 00:00 UTC instead of hourly
- update README to mention daily schedule

## Testing
- `python3 -m compileall -q .`
- `pip install -r requirements.txt` *(fails: cannot access pypi.org)*
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6853616853d4832bb6292dc453b55e28