### PR TITLE
Refine README and outline queue work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,15 @@
 # TokenDrip
 
-Schedule long-running OpenAI jobs that automatically pause when daily free-token quotas (1M/10M tokens) are hit and resume at 00 UTC. Perfect for batch processing, research, and automated content generation without manual quota management.
+Token dripping is a strategy for long OpenAI workloads: instead of blasting millions of tokens in one go, you “let the faucet trickle.” Each day you run just enough requests to stay inside the free-token bucket granted by the data-sharing incentive (1 M or 10 M tokens, depending on model group), checkpoint the partial results, and then pause. At 00 UTC the quota refills, your job wakes up, loads its last checkpoint, and continues. The cycle repeats until the task completes, giving you effectively cost-free processing for projects that would otherwise be too big for a single day’s allowance.
 
 ## Quick Start
 
-1. Fork this repository
-2. Add your `OPENAI_API_KEY` as a repository secret
-3. Push to trigger the workflow
-4. Tasks run hourly via GitHub Actions
+1. Fork this repository.
+2. Add your `OPENAI_API_KEY` as a repository secret.
+3. Push to trigger the workflow.
+4. The GitHub Action wakes hourly, spending available tokens until the daily bucket is empty.
 
-## Usage
-
-Place Python task files in `tasks/` directory. Each task must implement:
-
-```python
-min_chunk_tokens = 80_000  # Minimum tokens needed per chunk
-def init_state(): return {}  # Initial state
-def run_chunk(budget, state): return (used_tokens, new_state)
-```
-
-Tasks are automatically discovered and executed with intelligent quota management.
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) file. 
+MIT License - see [LICENSE](LICENSE) for details.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+- [ ] Implement basic queue data structure to store task metadata and state paths.
+- [ ] Update runner to pull the next task from the queue at 00 UTC and resume it from its checkpoint.
+- [ ] Schedule the queue runner to start at 00 UTC each day.
+- [ ] After each chunk, update the queue entry with the new state and tokens used.
+- [ ] If daily quota is exhausted, persist the queue and exit until the following day.
+- [ ] Allow multiple tasks in the queue so they can progress one after another across days.


### PR DESCRIPTION
## Summary
- describe token dripping directly in the README
- drop task usage details and todo list from the README
- create a TODO checklist for adding a task queue

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6853605e0998832b9a8a1cd132b21e5a